### PR TITLE
native serialize and deserialize functions for vector3.rs

### DIFF
--- a/src/vector3.rs
+++ b/src/vector3.rs
@@ -39,6 +39,31 @@ impl Vector3 {
             z: z.try_into().unwrap(),
         }
     }
+
+    pub fn serialize(&self) -> String {
+        format!("x: {}, y: {}, z: {}", self.x, self.y, self.z)
+    }
+
+    pub fn deserialize(s: &str) -> Option<Self> {
+        let parts: Vec<&str> = s.split(", ").collect();
+        if parts.len() != 3 {
+            return None;
+        }
+
+        let x_part: Vec<&str> = parts[0].split(": ").collect();
+        let y_part: Vec<&str> = parts[1].split(": ").collect();
+        let z_part: Vec<&str> = parts[2].split(": ").collect();
+
+        if x_part.len() != 2 || y_part.len() != 2 || z_part.len() != 2 {
+            return None;
+        }
+
+        let x: f64 = x_part[1].parse().ok()?;
+        let y: f64 = y_part[1].parse().ok()?;
+        let z: f64 = z_part[1].parse().ok()?;
+
+        Some(Self { x, y, z })
+    }
 }
 
 impl Add for Vector3 {


### PR DESCRIPTION
I ran into an issue where I needed Vector3 to be serializable and deserializable, so I added these two functions. I didn't want to use serde, figuring this would be a simple change and wouldn't require adding a library for a collection of 3 f64s. If this is not rustic, or otherwise goes against the library's grain, please let me know. 